### PR TITLE
Make example clear with dependent keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ import computed from 'ember-new-computed';
 export default Ember.Object({
   first: null,
   last: null,
-  name: computed({
+  name: computed('first', 'last', {
     get: function() {
       return this.get('first') + ' ' + this.get('last');
     },


### PR DESCRIPTION
The syntax looked different, like the new version figured out when to update based on internal `this.get` calls. Adding the dependent keys makes it clearer I think.
